### PR TITLE
Add default .do/app.yaml file pattern

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,8 @@
   entry: hooks/doctl-app-spec-validate.sh
   language: script
   types: [shell]
+  pass_filenames: true
+  files: |
+      (?x)^(
+          \.do/app\.y(a)?ml
+      )$


### PR DESCRIPTION
Previously, the `v0.0.1` hook did not automatically run if a `.do/app.yaml` was present.